### PR TITLE
Lex2regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +463,7 @@ version = "0.1.0-alpha"
 dependencies = [
  "clap 4.2.7",
  "criterion",
+ "regex",
 ]
 
 [[package]]
@@ -561,6 +577,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "4.2.7", features = ["derive", "cargo"] }
+regex = "1.8.1"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/token.rs
+++ b/src/token.rs
@@ -27,53 +27,6 @@ pub enum Token {
     Ident(String), // Identifier is a alphanumeric string
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum GrammarItem {
-    Product,
-    Quotient,
-    Sum,
-    Sub,
-
-    Int(i32),
-    Float(f32),
-
-    Paren,
-}
-
-impl TryFrom<Token> for GrammarItem {
-    type Error = String;
-
-    fn try_from(value: Token) -> Result<Self, Self::Error> {
-        match value {
-            Token::Operator(c) => match c.as_str() {
-                "+" => Ok(Self::Sum),
-                "-" => Ok(Self::Sub),
-                "*" => Ok(Self::Product),
-                "/" => Ok(Self::Quotient),
-                _ => Err(format!("The `{c}` is not an operator!")),
-            },
-
-            Token::OpenParen | Token::CloseParen => Ok(Self::Paren),
-
-            Token::Int(v) => Ok(Self::Int(v)),
-            Token::Float(v) => Ok(Self::Float(v)),
-
-            _ => Err("Not implemented yet.".to_string()),
-        }
-    }
-}
-
-impl fmt::Display for GrammarItem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let GrammarItem::Int(val) = &self {
-            return write!(f, "Int:{}", val);
-        } else if let GrammarItem::Float(val) = &self {
-            return write!(f, "Float:{}", val);
-        }
-        write!(f, "{:?}", &self)
-    }
-}
-
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Token::Int(val) = &self {


### PR DESCRIPTION
Improve the lexer using regex so it's more easy and concise.

**The performances are too slow :**

- A simple input `1 + 1` is lexed in 198ns and with the new regex lexer, it's lex in 1.06ms. It's an augmentation in the runtime of **535253.5%** !

- And a much complex one `func foo(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z) a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r + s + t + u + v + w + x + y + z` takes 18µs with the current lexer and with the new regex lexer, it's lex in 1.12ms. It's an augmentation in the runtime of **6122%** !

