### PR TITLE
Allow multiple lines in one REPL

### DIFF
--- a/benches/lexer_benchmark.rs
+++ b/benches/lexer_benchmark.rs
@@ -1,20 +1,16 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mona::lexer::Lexer;
-use criterion::{
-    black_box,
-    criterion_group,
-    criterion_main,
-    Criterion
-};
 
 fn simple_lexer_benchmark(c: &mut Criterion) {
-    c.bench_function(
-        "lexer 1 + 1",
-        |b| b.iter(|| {
+    c.bench_function("lexer 1 + 1", |b| {
+        b.iter(|| {
             let text = black_box(String::from("1 + 1"));
             let mut lexer = Lexer::new(&text, "<benches>".to_string());
-            lexer.make_tokens().expect("An error was occured when benchmarking `simple_lexer_benchmark`.");
+            lexer
+                .make_tokens()
+                .expect("An error was occured when benchmarking `simple_lexer_benchmark`.");
         })
-    );
+    });
 }
 
 fn lex_func_benchmark(c: &mut Criterion) {
@@ -28,7 +24,7 @@ fn lex_func_benchmark(c: &mut Criterion) {
     );
 }
 
-criterion_group!{
+criterion_group! {
     name = benches;
     config = Criterion::default();
     targets = simple_lexer_benchmark, lex_func_benchmark

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -94,8 +94,8 @@ pub fn main_loop(flags: Flags) {
         loop {
             let mut lexer = Lexer::new(&input, "<stdin>".to_string());
             let lexer_result = lexer.make_tokens();
-            
-            input.clear(); 
+
+            input.clear();
 
             let tokens = match lexer_result {
                 Ok(toks) => toks,
@@ -122,7 +122,6 @@ pub fn main_loop(flags: Flags) {
                     continue 'main;
                 }
             }
-            
         }
 
         stdout.flush().unwrap();

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -60,7 +60,6 @@ pub fn main_loop(flags: Flags) {
                 continue;
             }
         }
-        input = String::from(input);
 
         if input.as_str() == ".quit\n" {
             break;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -48,7 +48,7 @@ impl<'a> Lexer<'a> {
                 '0'..='9' | '.' | 'A'..='z' => {
                     let num = Self::make_word(&self.text, self.pos)?;
 
-                    self.column += num.1.0;
+                    self.column += num.1 .0;
 
                     let (tok, new_pos) = num;
 
@@ -83,7 +83,7 @@ impl<'a> Lexer<'a> {
                         self.line,
                         if self.line == 1 {
                             self.column as u32
-                        }else {
+                        } else {
                             self.column as u32 - 1
                         },
                         self.filename.clone(), //TODO: Try to remove .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,10 @@ fn main() {
         matches.get_flag("parser"),
         matches.get_flag("verbose"),
     );
-    println!("Mona v{}, to exit enter `.quit` and to finish a query just enter `.eof`.", env!("CARGO_PKG_VERSION"));
+    println!(
+        "Mona v{}, to exit enter `.quit` and to finish a query just enter `.eof`.",
+        env!("CARGO_PKG_VERSION")
+    );
 
     cfg!(debug_assertions).then(|| {
         println!("  You're in a debug binary, if it's not intentional, you should change.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         matches.get_flag("parser"),
         matches.get_flag("verbose"),
     );
-    println!("Mona v{}, to exit enter `.quit`", env!("CARGO_PKG_VERSION"));
+    println!("Mona v{}, to exit enter `.quit` and to finish a query just enter `.eof`.", env!("CARGO_PKG_VERSION"));
 
     cfg!(debug_assertions).then(|| {
         println!("  You're in a debug binary, if it's not intentional, you should change.");


### PR DESCRIPTION
The purpose of this issue was to enable multiple line in one "query" and the goal was achieved.

**Before merge :**
- [x] Fix the issue #11, when there is a `IllegalCharError`, the error doesn't point to the correct char,
```console
$ mona
Mona v0.1.0-alpha, to exit enter `.quit` and to finish a query just enter `.eof`.
  You're in a debug binary, if it's not intentional, you should change.
 Flags: Lexer,Parser,
~> a
 > @
 > .eof
Err: Lexer, in file `<stdin>` at line 1 :
 ... |
  1  | a
 ... |   ^
         Illegal Character
~> 
```
should look like that,
```console
$ mona
Mona v0.1.0-alpha, to exit enter `.quit` and to finish a query just enter `.eof`.
  You're in a debug binary, if it's not intentional, you should change.
 Flags: Lexer,Parser,
~> a
 > @
 > .eof
Err: Lexer, in file `<stdin>` at line 1 :
 ... |
  2  | @
 ... | ^
       Illegal Character
~> 
```